### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,6 @@
 name: Rust
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/thoser666/rivulet/security/code-scanning/1](https://github.com/thoser666/rivulet/security/code-scanning/1)

To fix the problem, an explicit `permissions` block should be added to the workflow, specifying only the minimal permissions required for the workflow's actions. In this case, the workflow comprises only reading the repository (`actions/checkout` is used and the build/tests steps only read files), so the minimal permission set is `contents: read`. The best practice is to add `permissions: contents: read` at the workflow (root) level to ensure all jobs use these least-privilege permissions by default, unless a specific job requires more (which can then be overridden at the job level). The change should be implemented by adding the following block after the `name:` line and before `on:`, i.e., making it the second entry in the file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
