### PR TITLE
Potential fix for code scanning alert no. 44: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [ "**" ]
   pull_request:
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Potential fix for [https://github.com/thoser666/rivulet/security/code-scanning/44](https://github.com/thoser666/rivulet/security/code-scanning/44)

Add an explicit workflow-level `permissions` block near the top of `.github/workflows/ci.yml` (right after `on:` is a standard location), with at least:

- `contents: read`

This is the least-privilege baseline and satisfies the CodeQL recommendation without changing existing build/test behavior. Since the visible jobs only need repository read access (`actions/checkout` + local build/test commands), this is the safest single fix. If any hidden job later needs write scopes, it can define a job-level `permissions` override.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
